### PR TITLE
catkin_simple: 0.1.2-4 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,10 +1,21 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   ubuntu:
   - trusty
 repositories:
+  catkin_simple:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/catkin_simple-release.git
+      version: 0.1.2-4
+    source:
+      type: git
+      url: https://github.com/zurich-eye/catkin_simple.git
+      version: master
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_simple` to `0.1.2-4`:
- upstream repository: https://github.com/zurich-eye/catkin_simple.git
- release repository: https://github.com/zurich-eye/catkin_simple-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
